### PR TITLE
Fixed NULL insertion values

### DIFF
--- a/client/components/loggedIn.jsx
+++ b/client/components/loggedIn.jsx
@@ -3,7 +3,7 @@ module.exports = React.createClass({
   displayName : 'LoggedIn',
 
   postApi: function() {
-    $.post('/data/user', JSON.stringify(this.state.profile));
+    $.post('/data/user', this.state.profile);
   },
 
 


### PR DESCRIPTION
Fixed post error by removing JSON stringify from shorthand post method. Properly inserts users with no null value.
